### PR TITLE
Changed toDict() to support tuples with embedded DotMap elements

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -108,14 +108,14 @@ class DotMap(MutableMapping, OrderedDict):
 					v = d
 				else:
 					v = v.toDict()
-			elif type(v) is list:
+			elif type(v) in (list, tuple):
 				l = []
 				for i in v:
 					n = i
 					if type(i) is DotMap:
 						n = i.toDict()
 					l.append(n)
-				v = l
+				v = (type(v) is tuple) and tuple(l) or l
 			d[k] = v
 		return d
 


### PR DESCRIPTION
Made a minor change in toDict() to allow it to recursively convert DotMaps in a tuple as well as in a list.

Before change

```python
>>> dm = dotmap.DotMap({'a': 1, 'b': (11, 22, dotmap.DotMap({'c': 3}))})
>>> dm
DotMap([('a', 1), ('b', (11, 22, DotMap([('c', 3)])))])
>>> dm.toDict()
{'a': 1, 'b': (11, 22, DotMap([('c', 3)]))}
>>>
```

After change
```python
>>> dm = dotmap.DotMap({'a': 1, 'b': (11, 22, dotmap.DotMap({'c': 3}))})
>>> dm
DotMap([('a', 1), ('b', (11, 22, DotMap([('c', 3)])))])
>>> dm.toDict()
{'a': 1, 'b': (11, 22, {'c': 3})}
>>>
```
