### PR TITLE
Add ability for automatic increment when a key is not defined.

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -90,6 +90,15 @@ class DotMap(MutableMapping, OrderedDict):
     def __contains__(self, k):
         return self._map.__contains__(k)
 
+    def __add__(self, other):
+        if not self.keys():
+            return other
+        else:
+            self_type = type(self).__name__
+            other_type = type(other).__name__
+            msg = "unsupported operand type(s) for +: '{}' and '{}'"
+            raise TypeError(msg.format(self_type, other_type))
+
     def __str__(self):
         items = []
         for k,v in self.__call_items(self._map):


### PR DESCRIPTION
Howdy,
When using addict, I've gotten very  spoiled with code like:

```
from addict import Dict
my_counters = Dict()

for stuff in pages:
    my_counters.page += 1
```

I prefer using DotMap in general, so I was happy to see that the "automagic" adding appears to be as simple as adding the `def __add__()` function (which I copied from addict's project) to the DotMap object.

Are you interested in merging this change?

Thanks