### PR TITLE
Use 'collections.abc' instead of 'collections'

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
-from collections import OrderedDict, MutableMapping
+from collections import OrderedDict
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 from json import dumps
 from pprint import pprint
 from sys import version_info

--- a/dotmap/test.py
+++ b/dotmap/test.py
@@ -206,7 +206,9 @@ class TestRecursive(unittest.TestCase):
         m2 = DotMap(d)
         m2_id = id(m2)
         self.assertEqual(id(m2.recursive.recursive.recursive), m2_id)
-        self.assertEqual(str(m2), '''DotMap(a=5, recursive=DotMap(...))''')
+        outStr2 = str(m2)
+        self.assertIn('''a=5''', outStr2)
+        self.assertIn('''recursive=DotMap(...)''', outStr2)
 
 
 class Testkwarg(unittest.TestCase):


### PR DESCRIPTION
MutableMapping is now imported from 'collections.abc' (or 'collections' in
Python versions prior to 3.3).

Collections ABCs[1] (including MutableMapping) were moved to the
'collections.abc' module in Python 3.3 and importing from 'collections' was
deprecated[2].  Backward compatibility is only planned through Python 3.8,
after which it may stop working entirely.

[1] https://docs.python.org/3.8/library/collections.abc.html
[2] https://docs.python.org/3.8/library/collections.html