### PR TITLE
Fixed setdefault not returning value

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -221,7 +221,7 @@ class DotMap(MutableMapping, OrderedDict):
     def popitem(self):
         return self._map.popitem()
     def setdefault(self, key, default=None):
-        self._map.setdefault(key, default)
+        return self._map.setdefault(key, default)
     def update(self, *args, **kwargs):
         if len(args) != 0:
             self._map.update(*args)


### PR DESCRIPTION
The `setdefault` method should return the setted value for chained edit. The return statement was missing
Fixes #54 