### PR TITLE
Raise AttributeError on trying to get magic method/property

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -83,6 +83,9 @@ class DotMap(MutableMapping, OrderedDict):
             self[k] = v
 
     def __getattr__(self, k):
+        if k.startswith('__') and k.endswith('__'):
+            raise AttributeError(k)
+
         if k in {'_map','_dynamic','_ipython_canary_method_should_not_exist_'}:
             return super(DotMap, self).__getattr__(k)
 


### PR DESCRIPTION
Fixes: #63

Unwrap tries to query the __wrapped__ property of the DotMap class. As
there is no implementation of __wrapped__; it follows down through the
__getattr__, to __getitem__ and then because not known it calls
__setitem__ to point __wrapped__ at the class. As unwrap is trying to
walk recursively through the stack it then does the same thing again
with the returned instance of the class.

I took a look at cpython to see how other classes handle this scenario
and found that Enum and other classes explicitly exclude dunder
properties, rasing AttributeError. I propose that to solve this we
follow the same pattern.

Test Plan:

Try to unwrap an imported object of class DotMap.