### PR TITLE
fixup for circular and self references in __str__

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -112,12 +112,17 @@ class DotMap(MutableMapping, OrderedDict):
             msg = "unsupported operand type(s) for +: '{}' and '{}'"
             raise TypeError(msg.format(self_type, other_type))
 
-    def __str__(self):
+    def __str__(self, seen = None):
         items = []
+        seen = set() if seen is None else seen
         for k,v in self.__call_items(self._map):
-            # recursive assignment case
-            if id(v) == id(self):
-                items.append('{0}={1}(...)'.format(k, self.__class__.__name__))
+            # circular assignment case
+            if isinstance(v, self.__class__):
+                if id(v) in seen:
+                    items.append('{0}={1}(...)'.format(k, self.__class__.__name__))
+                else:
+                    seen.add(id(v))
+                    items.append('{0}={1}'.format(k, v.__str__(seen)))
             else:
                 items.append('{0}={1}'.format(k, repr(v)))
         joined = ', '.join(items)


### PR DESCRIPTION
Consider: 
```#!/usr/bin/env python3

from dotmap import DotMap

dm1 = DotMap(n = 'dm1', o = None)
dm2 = DotMap(n = 'dm2', o = dm1)
dm1.o = dm2

dm3 = DotMap(n = 'dm3', o = None)
dm3.o = dm3

print(dm1)
print(dm3)
```

`dm3` (self reference) is currently covered by `__str__`.  

`dm1` and `dm2` create a circular reference, which will result in a max recursion depth error.

Output from above with this MR:

```
DotMap(n='dm1', o=DotMap(n='dm2', o=DotMap(n='dm1', o=DotMap(...))))
DotMap(n='dm3', o=DotMap(n='dm3', o=DotMap(...)))
```
