### PR TITLE
Fix circular references

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -114,11 +114,7 @@ class DotMap(MutableMapping, OrderedDict):
 
     def __str__(self, seen = None):
         items = []
-<<<<<<< HEAD
         seen = {id(self)} if seen is None else seen
-=======
-        seen = set() if seen is None else seen
->>>>>>> upstream/master
         for k,v in self.__call_items(self._map):
             # circular assignment case
             if isinstance(v, self.__class__):

--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -112,12 +112,17 @@ class DotMap(MutableMapping, OrderedDict):
             msg = "unsupported operand type(s) for +: '{}' and '{}'"
             raise TypeError(msg.format(self_type, other_type))
 
-    def __str__(self):
+    def __str__(self, seen = None):
         items = []
+        seen = set() if seen is None else seen
         for k,v in self.__call_items(self._map):
-            # recursive assignment case
-            if id(v) == id(self):
-                items.append('{0}={1}(...)'.format(k, self.__class__.__name__))
+            # circular assignment case
+            if isinstance(v, self.__class__):
+                if id(v) in seen:
+                    items.append('{0}={1}(...)'.format(k, self.__class__.__name__))
+                else:
+                    seen.add(id(v))
+                    items.append('{0}={1}'.format(k, v.__str__(seen)))
             else:
                 items.append('{0}={1}'.format(k, repr(v)))
         joined = ', '.join(items)

--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -114,7 +114,7 @@ class DotMap(MutableMapping, OrderedDict):
 
     def __str__(self, seen = None):
         items = []
-        seen = set() if seen is None else seen
+        seen = {id(self)} if seen is None else seen
         for k,v in self.__call_items(self._map):
             # circular assignment case
             if isinstance(v, self.__class__):


### PR DESCRIPTION
Sorry for the double PR -- noticed something:

Original PR, `dm1` / `dm3` is shown twice (unnecessarily):
```
DotMap(n='dm1', o=DotMap(n='dm2', o=DotMap(n='dm1', o=DotMap(...))))
DotMap(n='dm3', o=DotMap(n='dm3', o=DotMap(...)))
```
Output for this PR: 
```
DotMap(n='dm1', o=DotMap(n='dm2', o=DotMap(...)))
DotMap(n='dm3', o=DotMap(...))
```
