### PR TITLE
fix for circular references in __init__

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -23,11 +23,12 @@ class DotMap(MutableMapping, OrderedDict):
         self._map = OrderedDict()
         self._dynamic = kwargs.pop('_dynamic', True)
         self._prevent_method_masking = kwargs.pop('_prevent_method_masking', False)
+        trackedIDs = kwargs.pop('_trackedIDs', {})
 
         if args:
             d = args[0]
             # for recursive assignment handling
-            trackedIDs = {id(d): self}
+            trackedIDs[id(d)] = self
 
             src = []
             if isinstance(d, MutableMapping):
@@ -42,8 +43,8 @@ class DotMap(MutableMapping, OrderedDict):
                     if id(v) in trackedIDs:
                         v = trackedIDs[id(v)]
                     else:
-                        v = self.__class__(v, _dynamic=self._dynamic, _prevent_method_masking = self._prevent_method_masking)
                         trackedIDs[id(v)] = v
+                        v = self.__class__(v, _dynamic=self._dynamic, _prevent_method_masking = self._prevent_method_masking, _trackedIDs = trackedIDs)
                 if type(v) is list:
                     l = []
                     for i in v:

--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -144,21 +144,28 @@ class DotMap(MutableMapping, OrderedDict):
     def __repr__(self):
         return str(self)
 
-    def toDict(self):
+    def toDict(self, _seen = None):
         d = {}
+        if _seen is None:
+            _seen = set()
         for k,v in self.items():
+            if id(v) in _seen: continue
+            _seen.add(id(v))
             if issubclass(type(v), DotMap):
                 # bizarre recursive assignment support
                 if id(v) == id(self):
                     v = d
                 else:
-                    v = v.toDict()
+                    v = v.toDict(_seen = _seen)
             elif type(v) in (list, tuple):
                 l = []
                 for i in v:
                     n = i
+                    if id(i) in _seen: continue
+                    _seen.add(id(i))
+
                     if issubclass(type(i), DotMap):
-                        n = i.toDict()
+                        n = i.toDict(_seen)
                     l.append(n)
                 if type(v) is tuple:
                     v = tuple(l)

--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -163,9 +163,6 @@ class DotMap(MutableMapping, OrderedDict):
                 idv = id(v)
                 if idv in seen:
                     v = seen[idv]
-                # bizarre recursive assignment support
-                elif idv == id(self):
-                    v = d
                 else:
                     v = v.toDict(seen = seen)
             elif type(v) in (list, tuple):


### PR DESCRIPTION
Had another use case where there was an issue with circular references, this time in `__init__`.

Also updated `toDict()`