### PR TITLE
Include license metadata in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,5 @@ setup(
     classifiers=[],
     long_description=long_description,
     long_description_content_type="text/markdown",
+    license="MIT",
 )


### PR DESCRIPTION
Having it here simplifies showing this information in pypi, with `pip show`, or parsing it with tools like pip-licenses.