### PR TITLE
require Python 3.6+ and remove download_url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     author='Chris Redford',
     author_email='credford@gmail.com',
     url='https://github.com/drgrib/dotmap',  # use the URL to the github repo
-    download_url='https://github.com/drgrib/dotmap/tarball/1.0',
     keywords=['dict', 'dot', 'map', 'order', 'ordered',
               'ordereddict', 'access', 'dynamic'],  # arbitrary keywords
     python_requires=">= 3.6",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     download_url='https://github.com/drgrib/dotmap/tarball/1.0',
     keywords=['dict', 'dot', 'map', 'order', 'ordered',
               'ordereddict', 'access', 'dynamic'],  # arbitrary keywords
+    python_requires=">= 3.6",
     classifiers=[],
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Since commit 0bf24f21 the library uses an f-string but that is only supported since Python 3.6 (closes #83).

Additionally remove the `download_url` setting from `setup.py`. That setting is generally not too useful and the current value points to the outdated 1.0 release. I think we should just remove it because it is just one more thing to update for each release.