### PR TITLE
migrate all settings from "setup.py" to "setup.cfg"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,26 @@
 [metadata]
-description-file = README.rst
+name          = dotmap
+version       = 1.3.30
+description   = ordered, dynamically-expandable dot-access dictionary
+
+long_description = file:README.md
+long_description_content_type = text/markdown
+
+author        = Chris Redford
+author_email  = credford@gmail.com
+url           = https://github.com/drgrib/dotmap
+license       = MIT
+# requires setuptools >= 42.0.0
+license_files = LICENSE.txt
+
+project_urls =
+    Code = https://github.com/drgrib/dotmap
+    Issue tracker = https://github.com/drgrib/dotmap/issues
+keywords = dict, dot, map, order, ordered, ordereddict, access, dynamic
+
+
+[options]
+python_requires = >= 3.6
+
+packages = dotmap
+

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,3 @@
 from setuptools import setup
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setup(
-	version = '1.3.30',
-    name='dotmap',
-    packages=['dotmap'],  # this must be the same as the name above
-    description='ordered, dynamically-expandable dot-access dictionary',
-    author='Chris Redford',
-    author_email='credford@gmail.com',
-    url='https://github.com/drgrib/dotmap',  # use the URL to the github repo
-    keywords=['dict', 'dot', 'map', 'order', 'ordered',
-              'ordereddict', 'access', 'dynamic'],  # arbitrary keywords
-    python_requires=">= 3.6",
-    classifiers=[],
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    license="MIT",
-)
+setup()


### PR DESCRIPTION
The setup.py mechanism is deprecated in favor of declarative package metadata.