### PR TITLE
remove compat code which is only required for ancient Python versions

### DIFF
--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -1,9 +1,6 @@
-from __future__ import print_function
+
 from collections import OrderedDict
-try:
-    from collections.abc import MutableMapping, Iterable
-except ImportError:
-    from collections import MutableMapping, Iterable
+from collections.abc import MutableMapping, Iterable
 from json import dumps
 from pprint import pprint
 from sys import version_info


### PR DESCRIPTION
This library requires Python 3.6+ anyway so we can just drop the old compatibility code.