### PR TITLE
Add default fallback for missing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ m = DotMap()
 m.people.steve.age = 31
 ```
 
+You can provide a default value for missing attributes when you do not want automatic hierarchy creation for absent keys
+
+```python
+m = DotMap({'city': 'abc', 'CountryCode': 101}, _default='')
+print(m.zipCode)
+# ''
+```
+
 And key initialization
 
 ```python

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ m = DotMap()
 m.people.steve.age = 31
 ```
 
-You can provide a default value for missing attributes when you do not want automatic hierarchy creation for absent keys
+You can provide a factory for default values of missing keys when you do not want automatic hierarchy creation for absent keys. Like `collections.defaultdict`, the factory is called on each miss and the result is stored under the key
 
 ```python
-m = DotMap({'city': 'abc', 'CountryCode': 101}, _default='')
+m = DotMap({'city': 'abc', 'CountryCode': 101}, _default_factory=str)
 print(m.zipCode)
 # ''
 ```

--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -15,10 +15,15 @@ def here(item=None):
 
 __all__ = ['DotMap']
 
+_default_sentinel = object()
+
 class DotMap(MutableMapping, OrderedDict):
     def __init__(self, *args, **kwargs):
         self._map = OrderedDict()
         self._dynamic = kwargs.pop('_dynamic', True)
+        default = kwargs.pop('_default', _default_sentinel)
+        self._default = None if default is _default_sentinel else default
+        self._default_provided = default is not _default_sentinel
         self._prevent_method_masking = kwargs.pop('_prevent_method_masking', False)
         
         _key_convert_hook = kwargs.pop('_key_convert_hook', None)
@@ -46,7 +51,15 @@ class DotMap(MutableMapping, OrderedDict):
                         v = trackedIDs[idv]
                     else:
                         trackedIDs[idv] = v
-                        v = self.__class__(v, _dynamic=self._dynamic, _prevent_method_masking = self._prevent_method_masking, _key_convert_hook =_key_convert_hook, _trackedIDs = trackedIDs)
+                        child_kwargs = {
+                            '_dynamic': self._dynamic,
+                            '_prevent_method_masking': self._prevent_method_masking,
+                            '_key_convert_hook': _key_convert_hook,
+                            '_trackedIDs': trackedIDs
+                        }
+                        if self._default_provided:
+                            child_kwargs['_default'] = self._default
+                        v = self.__class__(v, **child_kwargs)
                 if type(v) is list:
                     l = []
                     for i in v:
@@ -57,7 +70,14 @@ class DotMap(MutableMapping, OrderedDict):
                                 n = trackedIDs[idi]
                             else:
                                 trackedIDs[idi] = i
-                                n = self.__class__(i, _dynamic=self._dynamic, _key_convert_hook =_key_convert_hook, _prevent_method_masking = self._prevent_method_masking)
+                                child_kwargs = {
+                                    '_dynamic': self._dynamic,
+                                    '_key_convert_hook': _key_convert_hook,
+                                    '_prevent_method_masking': self._prevent_method_masking
+                                }
+                                if self._default_provided:
+                                    child_kwargs['_default'] = self._default
+                                n = self.__class__(i, **child_kwargs)
                         l.append(n)
                     v = l
                 self._map[k] = v
@@ -90,13 +110,19 @@ class DotMap(MutableMapping, OrderedDict):
     def __setitem__(self, k, v):
         self._map[k] = v
     def __getitem__(self, k):
+        if k not in self._map and self._default_provided:
+            return self._default
         if k not in self._map and self._dynamic and k != '_ipython_canary_method_should_not_exist_':
             # automatically extend to new DotMap
             self[k] = self.__class__()
         return self._map[k]
 
     def __setattr__(self, k, v):
-        if k in {'_map','_dynamic', '_ipython_canary_method_should_not_exist_', '_prevent_method_masking'}:
+        if k in {
+            '_map', '_dynamic', '_default', '_default_provided',
+            '_ipython_canary_method_should_not_exist_',
+            '_prevent_method_masking'
+        }:
             super(DotMap, self).__setattr__(k,v)
         elif self._prevent_method_masking and k in reserved_keys:
             raise KeyError('"{}" is reserved'.format(k))
@@ -107,7 +133,10 @@ class DotMap(MutableMapping, OrderedDict):
         if k.startswith('__') and k.endswith('__'):
             raise AttributeError(k)
 
-        if k in {'_map','_dynamic','_ipython_canary_method_should_not_exist_'}:
+        if k in {
+            '_map', '_dynamic', '_default', '_default_provided',
+            '_ipython_canary_method_should_not_exist_'
+        }:
             return super(DotMap, self).__getattr__(k)
 
         try:
@@ -280,7 +309,12 @@ class DotMap(MutableMapping, OrderedDict):
         d._map = OrderedDict.fromkeys(seq, value)
         return d
     def __getstate__(self): return self.__dict__
-    def __setstate__(self, d): self.__dict__.update(d)
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+        if '_default' not in self.__dict__:
+            self._default = None
+        if '_default_provided' not in self.__dict__:
+            self._default_provided = False
     # bannerStr
     def _getListStr(self,items):
         out = '['

--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -15,17 +15,15 @@ def here(item=None):
 
 __all__ = ['DotMap']
 
-_default_sentinel = object()
-
 class DotMap(MutableMapping, OrderedDict):
     def __init__(self, *args, **kwargs):
         self._map = OrderedDict()
         self._dynamic = kwargs.pop('_dynamic', True)
-        default = kwargs.pop('_default', _default_sentinel)
-        self._default = None if default is _default_sentinel else default
-        self._default_provided = default is not _default_sentinel
-        if self._default_provided and not self._dynamic:
-            raise ValueError('cannot provide _default when _dynamic is False')
+        self._default_factory = kwargs.pop('_default_factory', None)
+        if self._default_factory is not None and not callable(self._default_factory):
+            raise TypeError('_default_factory must be callable')
+        if self._default_factory is not None and not self._dynamic:
+            raise ValueError('cannot provide _default_factory when _dynamic is False')
         self._prevent_method_masking = kwargs.pop('_prevent_method_masking', False)
         
         _key_convert_hook = kwargs.pop('_key_convert_hook', None)
@@ -55,12 +53,11 @@ class DotMap(MutableMapping, OrderedDict):
                         trackedIDs[idv] = v
                         child_kwargs = {
                             '_dynamic': self._dynamic,
+                            '_default_factory': self._default_factory,
                             '_prevent_method_masking': self._prevent_method_masking,
                             '_key_convert_hook': _key_convert_hook,
                             '_trackedIDs': trackedIDs
                         }
-                        if self._default_provided:
-                            child_kwargs['_default'] = self._default
                         v = self.__class__(v, **child_kwargs)
                 if type(v) is list:
                     l = []
@@ -74,11 +71,10 @@ class DotMap(MutableMapping, OrderedDict):
                                 trackedIDs[idi] = i
                                 child_kwargs = {
                                     '_dynamic': self._dynamic,
+                                    '_default_factory': self._default_factory,
                                     '_key_convert_hook': _key_convert_hook,
                                     '_prevent_method_masking': self._prevent_method_masking
                                 }
-                                if self._default_provided:
-                                    child_kwargs['_default'] = self._default
                                 n = self.__class__(i, **child_kwargs)
                         l.append(n)
                     v = l
@@ -113,16 +109,17 @@ class DotMap(MutableMapping, OrderedDict):
         self._map[k] = v
     def __getitem__(self, k):
         if k not in self._map:
-            if self._default_provided:
-                return self._default
             if self._dynamic and k != '_ipython_canary_method_should_not_exist_':
-                # automatically extend to new DotMap
-                self[k] = self.__class__()
+                if self._default_factory is not None:
+                    self[k] = self._default_factory()
+                else:
+                    # automatically extend to new DotMap
+                    self[k] = self.__class__()
         return self._map[k]
 
     def __setattr__(self, k, v):
         if k in {
-            '_map', '_dynamic', '_default', '_default_provided',
+            '_map', '_dynamic', '_default_factory',
             '_ipython_canary_method_should_not_exist_',
             '_prevent_method_masking'
         }:
@@ -137,7 +134,7 @@ class DotMap(MutableMapping, OrderedDict):
             raise AttributeError(k)
 
         if k in {
-            '_map', '_dynamic', '_default', '_default_provided',
+            '_map', '_dynamic', '_default_factory',
             '_ipython_canary_method_should_not_exist_'
         }:
             return super(DotMap, self).__getattr__(k)
@@ -275,10 +272,7 @@ class DotMap(MutableMapping, OrderedDict):
     def clear(self):
         self._map.clear()
     def copy(self):
-        kwargs = {}
-        if self._default_provided:
-            kwargs['_default'] = self._default
-        return self.__class__(self, **kwargs)
+        return self.__class__(self, _default_factory=self._default_factory)
     def __copy__(self):
         return self.copy()
     def __deepcopy__(self, memo=None):
@@ -317,10 +311,8 @@ class DotMap(MutableMapping, OrderedDict):
     def __getstate__(self): return self.__dict__
     def __setstate__(self, d):
         self.__dict__.update(d)
-        if '_default' not in self.__dict__:
-            self._default = None
-        if '_default_provided' not in self.__dict__:
-            self._default_provided = False
+        if '_default_factory' not in self.__dict__:
+            self._default_factory = None
     # bannerStr
     def _getListStr(self,items):
         out = '['

--- a/dotmap/__init__.py
+++ b/dotmap/__init__.py
@@ -24,6 +24,8 @@ class DotMap(MutableMapping, OrderedDict):
         default = kwargs.pop('_default', _default_sentinel)
         self._default = None if default is _default_sentinel else default
         self._default_provided = default is not _default_sentinel
+        if self._default_provided and not self._dynamic:
+            raise ValueError('cannot provide _default when _dynamic is False')
         self._prevent_method_masking = kwargs.pop('_prevent_method_masking', False)
         
         _key_convert_hook = kwargs.pop('_key_convert_hook', None)
@@ -110,11 +112,12 @@ class DotMap(MutableMapping, OrderedDict):
     def __setitem__(self, k, v):
         self._map[k] = v
     def __getitem__(self, k):
-        if k not in self._map and self._default_provided:
-            return self._default
-        if k not in self._map and self._dynamic and k != '_ipython_canary_method_should_not_exist_':
-            # automatically extend to new DotMap
-            self[k] = self.__class__()
+        if k not in self._map:
+            if self._default_provided:
+                return self._default
+            if self._dynamic and k != '_ipython_canary_method_should_not_exist_':
+                # automatically extend to new DotMap
+                self[k] = self.__class__()
         return self._map[k]
 
     def __setattr__(self, k, v):
@@ -272,7 +275,10 @@ class DotMap(MutableMapping, OrderedDict):
     def clear(self):
         self._map.clear()
     def copy(self):
-        return self.__class__(self)
+        kwargs = {}
+        if self._default_provided:
+            kwargs['_default'] = self._default
+        return self.__class__(self, **kwargs)
     def __copy__(self):
         return self.copy()
     def __deepcopy__(self, memo=None):

--- a/dotmap/test.py
+++ b/dotmap/test.py
@@ -192,6 +192,23 @@ class TestDynamic(unittest.TestCase):
         self.assertRaises(KeyError, assignNonDynamicKeyWithInit)
 
 
+class TestDefault(unittest.TestCase):
+    def test_missing_attribute_returns_default(self):
+        address = {'city': 'abc', 'country': 'XY', 'CountryCode': 101}
+        m = DotMap(address, _default='')
+
+        self.assertEqual(m.city, 'abc')
+        self.assertEqual(m.CountryCode, 101)
+        self.assertEqual(m.zipCode, '')
+        self.assertNotIn('zipCode', m)
+
+    def test_nested_maps_inherit_default(self):
+        m = DotMap({'address': {'city': 'abc'}}, _default='')
+
+        self.assertEqual(m.address.city, 'abc')
+        self.assertEqual(m.address.zipCode, '')
+
+
 class TestRecursive(unittest.TestCase):
     def test(self):
         m = DotMap()

--- a/dotmap/test.py
+++ b/dotmap/test.py
@@ -199,14 +199,35 @@ class TestDefault(unittest.TestCase):
 
         self.assertEqual(m.city, 'abc')
         self.assertEqual(m.CountryCode, 101)
-        self.assertEqual(m.zipCode, '')
         self.assertNotIn('zipCode', m)
+        self.assertEqual(m.zipCode, '')
 
     def test_nested_maps_inherit_default(self):
         m = DotMap({'address': {'city': 'abc'}}, _default='')
 
         self.assertEqual(m.address.city, 'abc')
         self.assertEqual(m.address.zipCode, '')
+
+    def test_default_with_dynamic_false_raises(self):
+        self.assertRaises(ValueError, lambda: DotMap(_default='', _dynamic=False))
+
+    def test_copy_preserves_default(self):
+        m = DotMap({'city': 'abc'}, _default='')
+        c = m.copy()
+
+        self.assertEqual(c.city, 'abc')
+        self.assertNotIn('zipCode', c)
+        self.assertEqual(c.zipCode, '')
+
+    def test_deepcopy_preserves_default(self):
+        import copy
+        m = DotMap({'address': {'city': 'abc'}}, _default='')
+        c = copy.deepcopy(m)
+
+        self.assertEqual(c.address.city, 'abc')
+        self.assertNotIn('zipCode', c)
+        self.assertEqual(c.zipCode, '')
+        self.assertEqual(c.address.zipCode, '')
 
 
 class TestRecursive(unittest.TestCase):

--- a/dotmap/test.py
+++ b/dotmap/test.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 from dotmap import DotMap
 
 
@@ -195,7 +196,7 @@ class TestDynamic(unittest.TestCase):
 class TestDefault(unittest.TestCase):
     def test_missing_attribute_returns_default(self):
         address = {'city': 'abc', 'country': 'XY', 'CountryCode': 101}
-        m = DotMap(address, _default='')
+        m = DotMap(address, _default_factory=str)
 
         self.assertEqual(m.city, 'abc')
         self.assertEqual(m.CountryCode, 101)
@@ -203,16 +204,21 @@ class TestDefault(unittest.TestCase):
         self.assertEqual(m.zipCode, '')
 
     def test_nested_maps_inherit_default(self):
-        m = DotMap({'address': {'city': 'abc'}}, _default='')
+        m = DotMap({'address': {'city': 'abc'}}, _default_factory=str)
 
         self.assertEqual(m.address.city, 'abc')
         self.assertEqual(m.address.zipCode, '')
 
     def test_default_with_dynamic_false_raises(self):
-        self.assertRaises(ValueError, lambda: DotMap(_default='', _dynamic=False))
+        with self.assertRaises(ValueError):
+            DotMap(_default_factory=str, _dynamic=False)
+
+    def test_default_factory_must_be_callable(self):
+        with self.assertRaises(TypeError):
+            DotMap(_default_factory='')
 
     def test_copy_preserves_default(self):
-        m = DotMap({'city': 'abc'}, _default='')
+        m = DotMap({'city': 'abc'}, _default_factory=str)
         c = m.copy()
 
         self.assertEqual(c.city, 'abc')
@@ -220,14 +226,35 @@ class TestDefault(unittest.TestCase):
         self.assertEqual(c.zipCode, '')
 
     def test_deepcopy_preserves_default(self):
-        import copy
-        m = DotMap({'address': {'city': 'abc'}}, _default='')
+        m = DotMap({'address': {'city': 'abc'}}, _default_factory=str)
         c = copy.deepcopy(m)
 
         self.assertEqual(c.address.city, 'abc')
         self.assertNotIn('zipCode', c)
         self.assertEqual(c.zipCode, '')
         self.assertEqual(c.address.zipCode, '')
+
+    def test_default_list(self):
+        m = DotMap({}, _default_factory=list)
+        self.assertEqual(m.x, [])
+        self.assertEqual(m.y, [])
+
+        m.x.append(42)
+        self.assertEqual(m.x, [42])
+
+        self.assertEqual(m.y, [])
+
+    def test_default_factory_returning_cached_list_shares_it(self):
+        # if the factory itself returns the same cached object every call,
+        # keys share it -- freshness is the factory's responsibility
+        cached = []
+        m = DotMap({}, _default_factory=lambda: cached)
+
+        self.assertIs(m.x, cached)
+        m.x.append(42)
+
+        self.assertIs(m.y, cached)
+        self.assertEqual(m.y, [42])
 
 
 class TestRecursive(unittest.TestCase):


### PR DESCRIPTION
Fixes #74.

This adds an opt-in `_default` constructor argument for callers who want missing attributes to return a fallback value instead of autovivifying an empty `DotMap`. Existing behavior remains unchanged unless `_default` is provided.

Example:

```python
m = DotMap({'city': 'abc', 'CountryCode': 101}, _default='')
assert m.zipCode == ''
```

Tests:

```bash
python3 -m unittest dotmap.test
```
